### PR TITLE
Models Implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     },
     "dependencies": {
         "@fetchai/uagents": "file:",
-        "@jest/globals": "^29.7.0"
+        "@jest/globals": "^29.7.0",
+        "@types/node": "^22.7.5",
+        "zod": "^3.23.8"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@jest/globals':
         specifier: ^29.7.0
         version: 29.7.0
+      '@types/node':
+        specifier: ^22.7.5
+        version: 22.7.5
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@babel/core':
         specifier: ^7.25.8
@@ -32,7 +38,7 @@ importers:
         version: 29.7.0(@babel/core@7.25.8)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@12.20.55)
+        version: 29.7.0(@types/node@22.7.5)
       tsup:
         specifier: ^8.3.0
         version: 8.3.0(typescript@5.6.2)
@@ -1079,6 +1085,9 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -2288,6 +2297,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -2372,6 +2384,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
 snapshots:
 
@@ -3360,6 +3375,7 @@ snapshots:
   '@fetchai/uagents@file:':
     dependencies:
       '@jest/globals': 29.7.0
+      zod: 3.23.8
     transitivePeerDependencies:
       - supports-color
 
@@ -3385,7 +3401,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -3398,14 +3414,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@12.20.55)
+      jest-config: 29.7.0(@types/node@22.7.5)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -3430,7 +3446,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -3448,7 +3464,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -3470,7 +3486,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -3540,7 +3556,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -3675,7 +3691,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -3688,6 +3704,10 @@ snapshots:
       '@types/istanbul-lib-report': 3.0.3
 
   '@types/node@12.20.55': {}
+
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/stack-utils@2.0.3': {}
 
@@ -3925,13 +3945,13 @@ snapshots:
     dependencies:
       browserslist: 4.24.0
 
-  create-jest@29.7.0(@types/node@12.20.55):
+  create-jest@29.7.0(@types/node@22.7.5):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@12.20.55)
+      jest-config: 29.7.0(@types/node@22.7.5)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -4279,7 +4299,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -4299,16 +4319,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@12.20.55):
+  jest-cli@29.7.0(@types/node@22.7.5):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@12.20.55)
+      create-jest: 29.7.0(@types/node@22.7.5)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@12.20.55)
+      jest-config: 29.7.0(@types/node@22.7.5)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -4318,7 +4338,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@12.20.55):
+  jest-config@29.7.0(@types/node@22.7.5):
     dependencies:
       '@babel/core': 7.25.8
       '@jest/test-sequencer': 29.7.0
@@ -4343,7 +4363,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -4372,7 +4392,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -4382,7 +4402,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -4421,7 +4441,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -4456,7 +4476,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -4484,7 +4504,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       chalk: 4.1.2
       cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
@@ -4530,7 +4550,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -4549,7 +4569,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -4558,17 +4578,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 22.7.5
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@12.20.55):
+  jest@29.7.0(@types/node@22.7.5):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@12.20.55)
+      jest-cli: 29.7.0(@types/node@22.7.5)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5037,6 +5057,8 @@ snapshots:
 
   typescript@5.6.2: {}
 
+  undici-types@6.19.8: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -5120,3 +5142,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@3.23.8: {}

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,15 +1,47 @@
-import { ZodSchema } from 'zod';
+import { ZodSchema, z, ZodType, ZodTypeDef } from 'zod';
 import crypto from 'crypto';
 
-export class Model<T> {
-  private schema: ZodSchema<T>;
+export class Model<T extends Record<string, any>> {
+  private schema: ZodSchema;
 
-  constructor(schema: ZodSchema<T>) {
-    this.schema = schema;
+  constructor(schema: ZodSchema<T>);
+  constructor(exampleObject: T);
+  constructor(tsType: new () => T);
+  constructor(arg: ZodSchema<T> | T | (new () => T)) {
+    if (arg instanceof ZodSchema) {
+      this.schema = arg;
+    } else if (typeof arg === 'object') {
+      this.schema = this.inferSchemaFromObject(arg);
+    } else if (typeof arg === 'function') {
+      const instance = new arg();
+      this.schema = this.inferSchemaFromObject(instance);
+    } else {
+      throw new Error('Invalid input. Provide a Zod schema, example object, or TypeScript type.');
+    }
   }
 
-  validate(obj: T): T {
-    return this.schema.parse(obj);
+  private inferSchemaFromObject(obj: Record<string, unknown>): ZodSchema {
+    const schemaShape: Record<string, ZodType<any, ZodTypeDef, any>> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      schemaShape[key] = this.inferZodType(value);
+    }
+    return z.object(schemaShape);
+  }
+
+  private inferZodType(value: unknown): ZodType<any, ZodTypeDef, any> {
+    if (typeof value === 'string') return z.string();
+    if (typeof value === 'number') return z.number();
+    if (typeof value === 'boolean') return z.boolean();
+    if (value instanceof Date) return z.date();
+    if (Array.isArray(value)) return z.array(this.inferZodType(value[0] ?? z.unknown()));
+    if (typeof value === 'object' && value !== null) {
+      return z.lazy(() => this.inferSchemaFromObject(value as Record<string, unknown>));
+    }
+    return z.unknown();
+  }
+
+  validate(obj: unknown): T {
+    return this.schema.parse(obj) as T;
   }
 
   dumpJson(data: T): string {
@@ -17,11 +49,11 @@ export class Model<T> {
   }
 
   dump(data: T): T {
-    return data;
+    return this.schema.parse(data) as T;
   }
 
   buildSchemaDigest(): string {
-    const schemaDef = JSON.stringify(this.schema._def);
+    const schemaDef = JSON.stringify(this.schema);
     const digest = crypto.createHash('sha256').update(schemaDef).digest('hex');
     return `model:${digest}`;
   }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,1 +1,28 @@
-export const model = "tmp";
+import { ZodSchema } from 'zod';
+import crypto from 'crypto';
+
+export class Model<T> {
+  private schema: ZodSchema<T>;
+
+  constructor(schema: ZodSchema<T>) {
+    this.schema = schema;
+  }
+
+  validate(obj: T): T {
+    return this.schema.parse(obj);
+  }
+
+  dumpJson(data: T): string {
+    return JSON.stringify(data);
+  }
+
+  dump(data: T): T {
+    return data;
+  }
+
+  buildSchemaDigest(): string {
+    const schemaDef = JSON.stringify(this.schema._def);
+    const digest = crypto.createHash('sha256').update(schemaDef).digest('hex');
+    return `model:${digest}`;
+  }
+}


### PR DESCRIPTION
In the uAgents python package, models is implemented as a class that is inherited a custom subclass. When writing the node version for the Models class, we considered 2 approaches:

1. Keep Models as a class to be inherited
2. Implement Models as a constructor to create model objects that users can custom define schemas for

We decided implement our initial version of Models using the 2nd approach.

Considerations:
For typescript users, models class may feel redundant, as using native typescript types feels way more intuitive. However, we felt a models class is necessary to ensure standardized developer experience across javascript and typescript developers.